### PR TITLE
App-Cell fix

### DIFF
--- a/src/chess/board/board.component.html
+++ b/src/chess/board/board.component.html
@@ -11,7 +11,7 @@ DOES STUFF</button>
 
 <div class="row" *ngFor="let row of rows">
 <div class="col" *ngFor="let cell of row.cells">
-<app-cell [piece]="cell.getPiece()" [init]=cell.getStyle() ></app-cell>
+<app-cell class="fill"  [piece]="cell.getPiece()" [init]=cell.getStyle() ></app-cell>
 </div>
 </div>
 </div>


### PR DESCRIPTION
I ntoiced an issue the other day regarding how the components are
displayed (CSS wise) where the containing tag is smaller than what it
contains. Specifically the App-Cell component has this problem now. This
adds the class the the tag which fixes this.

I anticipate that otherwise this will result in problems when trying to
select a cell.